### PR TITLE
Play nice with other Test frameworks

### DIFF
--- a/src/main/scala/io/gatling/sbt/GatlingPlugin.scala
+++ b/src/main/scala/io/gatling/sbt/GatlingPlugin.scala
@@ -50,9 +50,9 @@ object GatlingPlugin extends AutoPlugin {
   /********************/
 
   private def gatlingBaseSettings(config: Configuration, parent: Configuration) = Seq(
-    testFrameworks in config := Seq(gatlingTestFramework),
+    testFrameworks in config += gatlingTestFramework,
     target in config := target.value / config.name,
-    testOptions in config += Argument("-m", "-rf", (target in config).value.getPath),
+    testOptions in config += Argument(gatlingTestFramework, "-m", "-rf", (target in config).value.getPath),
     javaOptions in config ++= DefaultJvmArgs ++ propagatedSystemProperties,
     sourceDirectory in config := (sourceDirectory in parent).value,
     parallelExecution in config := false,


### PR DESCRIPTION
Right now if you load the gatling plugin it throws out all the other test frameworks. 
Even if you add them back afterwards the other test frameworks get passed gatling's testOptions which they don't recognize.

This change does two things:
- add the GatlingFramework to the existing Seq instead of overwriting it 
- configures the gatling specific testOptions to only apply to the GatlingFramework