### PR TITLE
use JavaConverters instead of JavaConversions

### DIFF
--- a/src/main/scala/io/gatling/sbt/utils/CopyUtils.scala
+++ b/src/main/scala/io/gatling/sbt/utils/CopyUtils.scala
@@ -17,7 +17,7 @@ package io.gatling.sbt.utils
 
 import java.util.jar.JarFile
 
-import scala.collection.JavaConversions._
+import scala.collection.JavaConverters._
 
 import sbt._
 
@@ -43,7 +43,7 @@ object CopyUtils {
 
   private def withFileInJar[T](jarPath: File, fileName: String)(f: File => T) = {
     val jarFile = new JarFile(jarPath)
-    val possibleEntry = jarFile.entries().find(_.getName.endsWith(fileName))
+    val possibleEntry = jarFile.entries().asScala.find(_.getName.endsWith(fileName))
     possibleEntry match {
       case Some(entry) =>
         IO.withTemporaryFile("copy", "sbttemp") { file =>


### PR DESCRIPTION
JavaConversions is deprecated since Scala 2.12

https://github.com/scala/scala/blob/v2.12.3/src/library/scala/collection/JavaConversions.scala#L59